### PR TITLE
Put %{current_user: nil} in context when unauthed

### DIFF
--- a/lib/api/graphql/guardian_context.ex
+++ b/lib/api/graphql/guardian_context.ex
@@ -19,7 +19,7 @@ defmodule Api.GraphQL.GuardianContext do
          {:ok, current_user, _claims} <- ApiWeb.Guardian.resource_from_token(token) do
       %{current_user: current_user}
     else
-      _ -> %{}
+      _ -> %{current_user: nil}
     end
   end
 end


### PR DESCRIPTION
When there's no authentication, other middlewares expect current_user to
be nil, instead of the key being absent. This fixes modules like
RequireAdmin.